### PR TITLE
Memory Refraction --> Remove ROS

### DIFF
--- a/src/main/java/roboy/dialog/DialogSystem.java
+++ b/src/main/java/roboy/dialog/DialogSystem.java
@@ -48,8 +48,7 @@ public class DialogSystem {
         MultiOutputDevice multiOut = IO.getOutputs(rosMainNode);
 
 
-        Neo4jMemoryInterface memory
-                = new Neo4jMemory(rosMainNode);
+        Neo4jMemoryInterface memory = new Neo4jMemory();
 
         logger.info("Initializing analyzers...");
 

--- a/src/main/java/roboy/memory/DummyMemory.java
+++ b/src/main/java/roboy/memory/DummyMemory.java
@@ -9,7 +9,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 
 /**
- * Implements the high-level-querying tasks to the Memory services using RosMainNode.
+ * Implements the high-level-querying tasks to the Memory services.
  */
 public class DummyMemory implements Neo4jMemoryInterface {
     private final static Logger logger = LogManager.getLogger();

--- a/src/main/java/roboy/memory/Neo4jMemory.java
+++ b/src/main/java/roboy/memory/Neo4jMemory.java
@@ -5,23 +5,20 @@ import com.google.gson.reflect.TypeToken;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import roboy.memory.nodes.MemoryNodeModel;
-import roboy.ros.RosMainNode;
 
 import java.io.IOException;
 import java.lang.reflect.Type;
 import java.util.*;
 
 /**
- * Implements the high-level-querying tasks to the Memory services using RosMainNode.
+ * Implements the high-level-querying tasks to the Memory services.
  */
 public class Neo4jMemory implements Neo4jMemoryInterface {
 
-    private static RosMainNode rosMainNode;
     private Gson gson = new Gson();
     private final static Logger logger = LogManager.getLogger();
 
-    public Neo4jMemory (RosMainNode node){
-        Neo4jMemory.rosMainNode = node;
+    public Neo4jMemory (){
         logger.info("Using Neo4jMemory");
     }
 
@@ -34,8 +31,6 @@ public class Neo4jMemory implements Neo4jMemoryInterface {
     @Override
     public boolean save(MemoryNodeModel node) throws InterruptedException, IOException
     {
-//        if(!Config.MEMORY) return false;
-//        String response = rosMainNode.UpdateMemoryQuery(node.toJSON());
         String response = Neo4jMemoryOperations.update(node.toJSON());
         return response != null && (response.contains("OK"));
     }
@@ -48,7 +43,6 @@ public class Neo4jMemory implements Neo4jMemoryInterface {
      */
     public String getById(int id) throws InterruptedException, IOException
     {
-//        String result = rosMainNode.GetMemoryQuery("{'id':"+id+"}");
         String result = Neo4jMemoryOperations.get("{'id':"+id+"}");
         if(result == null || result.contains("FAIL")) return null;
 
@@ -63,8 +57,6 @@ public class Neo4jMemory implements Neo4jMemoryInterface {
      */
     public ArrayList<Integer> getByQuery(MemoryNodeModel query) throws InterruptedException, IOException
     {
-//        if(!Config.MEMORY) return new ArrayList<>();
-//        String result = rosMainNode.GetMemoryQuery(query.toJSON());
         String result = Neo4jMemoryOperations.get(query.toJSON());
         if(result == null || result.contains("FAIL")) return null;
         Type type = new TypeToken<HashMap<String, List<Integer>>>() {}.getType();
@@ -74,11 +66,7 @@ public class Neo4jMemory implements Neo4jMemoryInterface {
 
     public int create(MemoryNodeModel query) throws InterruptedException, IOException
     {
-//        if(!Config.MEMORY) return 0;
-        //String result = rosMainNode.CreateMemoryQuery(query.toJSON());
-        // Handle possible Memory error message.
-        String
-                result = Neo4jMemoryOperations.create(query.toJSON());
+        String result = Neo4jMemoryOperations.create(query.toJSON());
         if(result == null || result.contains("FAIL")) return 0;
         Type type = new TypeToken<Map<String,Integer>>() {}.getType();
         Map<String,Integer> list = gson.fromJson(result, type);
@@ -93,9 +81,7 @@ public class Neo4jMemory implements Neo4jMemoryInterface {
      */
     public boolean remove(MemoryNodeModel query) throws InterruptedException, IOException
     {
-        //Remove all fields which were not explicitly set, for safety.
         query.setStripQuery(true);
-//        String response = rosMainNode.DeleteMemoryQuery(query.toJSON());
         String response = Neo4jMemoryOperations.delete(query.toJSON());
         return response != null && response.contains("OK");
     }

--- a/src/main/java/roboy/memory/Neo4jMemoryInterface.java
+++ b/src/main/java/roboy/memory/Neo4jMemoryInterface.java
@@ -6,7 +6,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 
 /**
- * Implements the high-level-querying tasks to the Memory services using RosMainNode.
+ * Implements the high-level-querying tasks to the Memory services.
  */
 public interface Neo4jMemoryInterface extends Memory<MemoryNodeModel>
 {


### PR DESCRIPTION
Right, so this is my pull request. 

Jira Issues: SDE 19, SDE 20 (No longer required), SDE 21 (No longer required), SDE 23

So what was all done:

- Turns out that without ROS, we don't even need to start memory, since it is all static (yay!)
- I commented out all of the previous service calls and replaced them with calls from a new class, called RoslessCalls. 
- RoslessCalls connects with the Memory with a new class, called Service Replacement (see pull request in memory)

Todos:
- ~~Revert Git Ignore Changes~~ https://github.com/Roboy/roboy_dialog/pull/39/commits/ad1492095bab76c2893c4e91d3d088254d0c39a7
- ~~Link Memory Pull Request to this Pull Request~~ https://github.com/Roboy/roboy_memory/pull/41 
- Document changes accordingly

Note:

- ~~This does not include the patch to start ROS on launch, simply because we don't need to start memory anymore --> SDE45 will address this, when ROS variable is set, memory shall also boot~~ Included as of #40 
- ~~Tests will be disabled in SDE45 ~~ Included as of #40 