### PR TITLE
Fixed Base64 dependencies, nlu checkout, docs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ In order to compile, in the directory containing `pom.xml` run:
 mvn clean install
 ```
 
-Make sure to set the following environment variables to meaningful values (ROS can wasily be run via docker, for Neo4J installation docs look at `memory`):
+Make sure to set the following environment variables to meaningful values (ROS can easily be run via docker, for Neo4J installation docs look at `memory`):
 ```bash
 export NEO4J_ADDRESS=bolt://my-neo4j-database:7687                
 export NEO4J_USERNAME=user
@@ -36,7 +36,8 @@ Also have a look at `nlu/README.md` for getting the Word2Vec model.
 
 Afterwards, run the dialog system via
 ```bash
-java -cp dialog/target/roboy-dialog-system-2.1.9-jar-with-dependencies.jar roboy.dialog.DialogSystem
+java -Xmx6g -d64 -cp dialog/target/ \
+    roboy-dialog-system-2.1.9-jar-with-dependencies.jar roboy.dialog.DialogSystem
 ```
 
 ## How to extend it

--- a/dialog/pom.xml
+++ b/dialog/pom.xml
@@ -303,6 +303,12 @@
 
         <dependency>
             <groupId>org.apache.commons</groupId>
+            <artifactId>com.springsource.org.apache.commons.codec</artifactId>
+            <version>1.6.0</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.commons</groupId>
             <artifactId>com.springsource.org.apache.commons.httpclient</artifactId>
             <version>3.1.0</version>
         </dependency>


### PR DESCRIPTION
### Hotfixes for the dialog devel branch:

* Fix nlu submodule checkout
* Fix `decodeBase64()` dependency mixup
* Explicitely state memory requirement when starting dialog
* Initialize Sempre executors before first input
* Some doc typo fixes