### PR TITLE
Automatic download of roboy_enwik8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,5 +20,6 @@ local.properties
 .target
 
 resources/word2vec_toy_data_and_model
+resources_nlu/word2vec/roboy_enwik8.txt
 
 docs/doxyxml

--- a/README.md
+++ b/README.md
@@ -17,28 +17,64 @@ The implementation of the pipeline is in Java. Integrations with tools in other 
 
 The repository contains a project that can be readily imported into Eclipse. Best use the EGit Eclipse Plugin to check it out. The code can be executed by running de.roboy.dialog.DialogSystem.
 
-**UPD** (maven related)
+#### Building
+
 In order to compile, in the directory containing `pom.xml` run: 
 ```
 mvn clean install
 ```
 
-Make sure to set the following environment variables to meaningful values (ROS can easily be run via docker, for Neo4J installation docs look at `memory`):
+#### Make sure that ROS master is available
+
+Dialog is tied into the Roboy architecture as a ROS node.
+Therefore, make sure to set the following environment variables to meaningful values:
 ```bash
-export NEO4J_ADDRESS=bolt://my-neo4j-database:7687                
-export NEO4J_USERNAME=user
-export NEO4J_PASSWORD=pass
 export ROS_HOSTNAME=local-hostname
 export ROS_MASTER_URI=http://rosmaster:11311
 ```
 
-Also have a look at `nlu/README.md` for getting the Word2Vec model.
+If no remote development instance of ROS master is available, just run
+`roscore` in a [docker container](http://wiki.ros.org/docker/Tutorials/Docker).
 
-Afterwards, run the dialog system via
+#### Make sure that Neo4J is running
+
+The dialog system's memory module uses Neo4j, a graph database which is
+stores relations between enttities observed by roboy (names, hobbies, locations etc.).
+Therefore, make sure to set the following environment variables to meaningful values:
 ```bash
-java -Xmx6g -d64 -cp dialog/target/ \
-    roboy-dialog-system-2.1.9-jar-with-dependencies.jar roboy.dialog.DialogSystem
+export NEO4J_ADDRESS=bolt://my-neo4j-database:7687                
+export NEO4J_USERNAME=user
+export NEO4J_PASSWORD=pass
 ```
+
+If no remote development instance of Neo4j is available, just run
+`Neo4j` in a [docker container](https://neo4j.com/developer/docker/#_how_to_use_the_neo4j_docker_image). For more options and additional information, refer to `docs/Usage` in the
+memory module.
+
+#### Running the Dialog System
+
+Once the ROS and Neo4j dependencies are satisfied, run the dialog system via
+```bash
+java -Xmx6g -d64 -cp dialog/target/roboy-dialog-system-2.1.9-jar-with-dependencies.jar \
+    roboy.dialog.DialogSystem
+```
+
+#### Running NLU only
+
+```bash
+java -Xmx6g -d64 -cp \
+    nlu/parser/target/roboy-parser-2.0.0-jar-with-dependencies.jar \
+    edu.stanford.nlp.sempre.roboy.SemanticAnalyzerInterface.java
+```
+
+#### Using the Google Word2Vec Model in NLU
+
+For a more complete but also much more memory-intensive Word Vector model,
+the NLU module has the ability to parse the GoogleNews word vector collection,
+which can be retrieved from [here](https://s3.amazonaws.com/dl4j-distribution/GoogleNews-vectors-negative300.bin.gz).
+
+In order to use it, store and extract it under `resources_nlu/word2vec`. Then just set
+`WORD2VEC_GOOGLE: true` in `parser.properties`.
 
 ## How to extend it
 

--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,26 @@
     </modules>
 
     <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>1.6.0</version>
+                <executions>
+                    <execution>
+                        <id>Pull Word2Vec Corpus</id>
+                        <phase>clean</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <configuration>
+                            <executable>wget</executable>
+                            <commandlineArgs>-nv -c http://bot.roboy.org:8081/~roboy/roboy_enwik8.txt -O resources_nlu/word2vec/roboy_enwik8.txt</commandlineArgs>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
         <resources>
             <resource>
                 <directory>resources</directory>


### PR DESCRIPTION
The word vector file is now downloaded automatically from bot.roboy.org.

This is facilitated by a lighttpd instance running there. To prevent DDOS, the server is limited to 16 connections. The file is not password-protected, since we would have to put the password into the maven config then, which is open source.