### PR TITLE
Refactor GameStates

### DIFF
--- a/dialog/src/main/java/roboy/dialog/states/gameStates/ChooseGameState.java
+++ b/dialog/src/main/java/roboy/dialog/states/gameStates/ChooseGameState.java
@@ -8,6 +8,8 @@ import roboy.linguistics.Linguistics;
 import roboy.linguistics.sentenceanalysis.Interpretation;
 import roboy.talk.PhraseCollection;
 import roboy.talk.Verbalizer;
+import roboy.util.Maps;
+import roboy.util.Pair;
 import roboy.util.RandomList;
 
 import java.util.*;
@@ -36,9 +38,17 @@ public class ChooseGameState extends State {
     //Can't fill this at constructor or static constructor level, so it is done in act()
     private void fillExistingGameMap(){
         if(EXISTING_GAME_MAP.isEmpty()){
-            //TODO find a better solution for the value, can we somehow get the transitions from the method cleanly? Should we convert it to Static?
-            EXISTING_GAME_MAP.put("Akinator", (GameState) getTransition("chose20questions"));
-            EXISTING_GAME_MAP.put("Snapchat", (GameState) getTransition("choseSnapchat"));
+            addElement("Akinator", (GamingTwentyQuestionsState          .transitionName));
+            addElement("Snapchat", (GamingSnapchatState                 .transitionName));
+        }
+    }
+
+    private void addElement(String key, String transitionName){
+        if(getAllTransitions().containsKey(transitionName)){
+            EXISTING_GAME_MAP.put(key, (GameState) getTransition(transitionName));
+        }
+        else{
+            LOGGER.error("Cannot add "+transitionName+" to EXISTING_GAME_MAP because transition does not exist");
         }
     }
 
@@ -47,12 +57,12 @@ public class ChooseGameState extends State {
         fillExistingGameMap();
 
         //Pick a game that is playable
-        RandomList<String> randomList = new RandomList<String>();
+        RandomList<String> randomList = new RandomList<>();
         randomList.addAll(
                 //Streams to Filter, because why have Java 1.8 if we can't make use of it
                 //Basically: Get all keys, turn that list into a stream, filter the stream by whether the key's value (the game) is capable of starting. Then put all those who can start into a random list.
                 EXISTING_GAME_MAP.keySet().stream().filter(s -> EXISTING_GAME_MAP.get(s).canStartGame())
-                        .collect(Collectors.toCollection(RandomList::new)));
+                        .collect(Collectors.toCollection(ArrayList::new)));
 
         //If no games are playable
         if(randomList.isEmpty()){
@@ -127,7 +137,8 @@ public class ChooseGameState extends State {
         else{
             //Does game exist in Map --> Basically, should we launch a game...
             if(EXISTING_GAME_MAP.containsKey(game)) {
-                return getTransition(EXISTING_GAME_MAP.get(game).getTransitionName());
+                String transition = Maps.value2Key( getAllTransitions(), EXISTING_GAME_MAP.get(game)).get();
+                return getTransition(transition);
             }
             //Or repeat this state again, because we need to check something
             else{

--- a/dialog/src/main/java/roboy/dialog/states/gameStates/ChooseGameState.java
+++ b/dialog/src/main/java/roboy/dialog/states/gameStates/ChooseGameState.java
@@ -9,10 +9,11 @@ import roboy.linguistics.sentenceanalysis.Interpretation;
 import roboy.talk.PhraseCollection;
 import roboy.talk.Verbalizer;
 import roboy.util.Maps;
-import roboy.util.Pair;
 import roboy.util.RandomList;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
 import java.util.stream.Collectors;
 
 public class ChooseGameState extends State {

--- a/dialog/src/main/java/roboy/dialog/states/gameStates/ChooseGameState.java
+++ b/dialog/src/main/java/roboy/dialog/states/gameStates/ChooseGameState.java
@@ -2,7 +2,6 @@ package roboy.dialog.states.gameStates;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import roboy.dialog.Segue;
 import roboy.dialog.states.definitions.State;
 import roboy.dialog.states.definitions.StateParameters;
 import roboy.linguistics.Linguistics;
@@ -10,56 +9,107 @@ import roboy.linguistics.sentenceanalysis.Interpretation;
 import roboy.talk.PhraseCollection;
 import roboy.talk.Verbalizer;
 import roboy.util.RandomList;
-import java.util.Arrays;
-import java.util.List;
+
+import java.util.*;
+import java.util.stream.Collectors;
 
 public class ChooseGameState extends State {
 
-    private final static String TRANSITION_CHOSE_SNAPCHAT = "choseSnapchat";
-    private final static String TRANSITION_CHOSE_20_Q = "chose20questions";
+
+    /*
+    Hey, if you want to add a new GameState, you will need to add your GameState into the HashMap EXISTING_GAME_MAP.
+    If you implemented it correctly, all should work here without problems :)
+     */
+
     private final static String TRANSITION_EXIT = "exitGame";
 
-    private final static RandomList<String> EXISTING_GAMES = new RandomList<>(Arrays.asList("Snapchat", "Akinator"));
+    private final static HashMap<String, GameState> EXISTING_GAME_MAP = new HashMap<>(2); //CHANGE THE VALUE OF THIS TO THE AMOUNT OF GAMES YOU SHALL ADD (EFFICIENCY)
 
     private final Logger LOGGER = LogManager.getLogger();
 
     private String game = null;
     private String suggestedGame = null;
 
+
     public ChooseGameState(String stateIdentifier, StateParameters params) {
         super(stateIdentifier, params);
+    }
+    //Can't fill this at constructor or static constructor level, so it is done in act()
+    private void fillExistingGameMap(){
+        if(EXISTING_GAME_MAP.isEmpty()){
+            //TODO find a better solution for the value, can we somehow get the transitions from the method cleanly?
+            EXISTING_GAME_MAP.put("Akinator", (GameState) getTransition("chose20questions"));
+            EXISTING_GAME_MAP.put("Snapchat", (GameState) getTransition("choseSnapchat"));
+        }
     }
 
     @Override
     public Output act() {
-        do {
-            suggestedGame = EXISTING_GAMES.getRandomElement();
-        }
-        while(getRosMainNode() == null && suggestedGame == "Snapchat");
+        fillExistingGameMap();
 
-        return Output.say(String.format(PhraseCollection.GAME_ASKING_PHRASES.getRandomElement(), suggestedGame));
+        //Pick a game that is playable
+        RandomList<String> randomList = new RandomList<String>();
+        randomList.addAll( //Streams to Filter, because why have Java 1.8 if we can't make use of it
+                EXISTING_GAME_MAP.keySet().stream().filter(s -> EXISTING_GAME_MAP.get(s).canStartGame())
+                        .collect(Collectors.toCollection(RandomList::new)));
+
+        //If no games are playable
+        if(randomList.isEmpty()){
+            LOGGER.info("No games available");
+            suggestedGame = "exit";
+            return Output.say("I do not think I know any games that are playable in this environment. Should I try again?");
+        }
+        //Choose a random game that is playable
+        else{
+            suggestedGame = randomList.getRandomElement();
+            return Output.say(String.format(PhraseCollection.GAME_ASKING_PHRASES.getRandomElement(), suggestedGame));
+        }
     }
 
     @Override
     public Output react(Interpretation input) {
+        //Reset the Value of Game
+        game = "";
+
         Linguistics.UtteranceSentiment inputSentiment = getInference().inferSentiment(input);
         String inputGame = inferGame(input);
 
-        if (inputSentiment == Linguistics.UtteranceSentiment.POSITIVE){
-            game = suggestedGame;
-            return Output.say(Verbalizer.startSomething.getRandomElement());
-        } else if (!inputGame.isEmpty()){
-            game = inputGame;
-            if(game.equals("Snapchat") && getRosMainNode() == null){
-                game = "exit";
-                LOGGER.info("Trying to start Snapchat Game but ROS is not initialised.");
-                Segue s = new Segue(Segue.SegueType.CONNECTING_PHRASE, 0.5);
-                return Output.say(Verbalizer.rosDisconnect.getRandomElement() + String.format("What a pitty, %s. Snapchat is not possible right now. ",
-                        getContext().ACTIVE_INTERLOCUTOR.getValue().getName())).setSegue(s);
+        //Should we try again?
+        if(suggestedGame.equals("exit")){
+            if(inputSentiment == Linguistics.UtteranceSentiment.NEGATIVE){
+                game = suggestedGame;
             }
-            return Output.say(Verbalizer.startSomething.getRandomElement());
-        } else if (inputSentiment == Linguistics.UtteranceSentiment.NEGATIVE){
-            game = "exit";
+        }
+        //If a game can be played...
+        else {
+            //If you AGREE with the selected game, do this
+            if (inputSentiment == Linguistics.UtteranceSentiment.POSITIVE) {
+                //Can we run the game?
+                if(EXISTING_GAME_MAP.get(suggestedGame).canStartGame()) {
+                    game = suggestedGame;
+                    return Output.say(Verbalizer.startSomething.getRandomElement());
+                }
+                else{
+                    game = "exit";
+                    return EXISTING_GAME_MAP.get(suggestedGame).cannotStartWarning();
+                }
+            }
+            //If you suggested your OWN game, do this
+            if (!inputGame.isEmpty()) {
+                //Can we run the game?
+                if(EXISTING_GAME_MAP.get(inputGame).canStartGame()) {
+                    game = inputGame;
+                    return Output.say(Verbalizer.startSomething.getRandomElement());
+                }
+                else{
+                    game = "exit";
+                    return EXISTING_GAME_MAP.get(inputGame).cannotStartWarning();
+                }
+            }
+            //If you DISAGREE with the game, quit...
+            if (inputSentiment == Linguistics.UtteranceSentiment.NEGATIVE) {
+                game = "exit";
+            }
         }
 
         return Output.sayNothing();
@@ -67,31 +117,46 @@ public class ChooseGameState extends State {
 
     @Override
     public State getNextState() {
-
-        switch (game){
-            case "Akinator":
-                return getTransition(TRANSITION_CHOSE_20_Q);
-            case "Snapchat":
-                return getTransition(TRANSITION_CHOSE_SNAPCHAT);
-            case "exit":
-                return getTransition(TRANSITION_EXIT);
-            default:
-                return this;
+        if(game.equals("exit")) {
+            return getTransition(TRANSITION_EXIT);
         }
+        else{
+            if(EXISTING_GAME_MAP.containsKey(game)) {
+                return getTransition(EXISTING_GAME_MAP.get(game).getTransitionName());
+            }
+            else{
+                return this;
+            }
+        }
+//        switch (game){
+//            case "Akinator":
+//                return getTransition(TRANSITION_CHOSE_20_Q);
+//            case "Snapchat":
+//                return getTransition(TRANSITION_CHOSE_SNAPCHAT);
+//            case "exit":
+//                return getTransition(TRANSITION_EXIT);
+//            default:
+//                return this;
+//        }
 
     }
     
     private String inferGame(Interpretation input){
-
+    //VERY IMPORTANT: If your tags conflict, the one with higher priority in the hashmap shall be taken
         List<String> tokens = input.getTokens();
-        game = "";
-        if(tokens != null && !tokens.isEmpty()){
-            if(tokens.contains("akinator") || tokens.contains("guessing") || tokens.contains("questions")){
-                game = "Akinator";
-            } else if (tokens.contains("snapchat") || tokens.contains("filters") || tokens.contains("filter") || tokens.contains("mask")){
-                game = "Snapchat";
+        String game = "";
+        if(tokens != null && !tokens.isEmpty()) {
+            for (String key : EXISTING_GAME_MAP.keySet()) {
+                for (String tag : EXISTING_GAME_MAP.get(key).getTags()) {
+                    if (tokens.contains(tag)) {
+                        game = key;
+                        return game;
+                    }
+                }
             }
         }
         return game;
     }
+
+
 }

--- a/dialog/src/main/java/roboy/dialog/states/gameStates/GameState.java
+++ b/dialog/src/main/java/roboy/dialog/states/gameStates/GameState.java
@@ -1,0 +1,30 @@
+package roboy.dialog.states.gameStates;
+
+import roboy.dialog.states.definitions.State;
+import roboy.dialog.states.definitions.StateParameters;
+
+import java.util.Collection;
+
+public abstract class GameState extends State {
+
+    /**
+     * Create a state object with given identifier (state name) and parameters.
+     * <p>
+     * The parameters should contain a reference to a state machine for later use.
+     * The state will not automatically add itself to the state machine.
+     *
+     * @param stateIdentifier identifier (name) of this state
+     * @param params          parameters for this state, should contain a reference to a state machine
+     */
+    public GameState(String stateIdentifier, StateParameters params) {
+        super(stateIdentifier, params);
+    }
+
+    public abstract boolean canStartGame();
+
+    public abstract Output cannotStartWarning();
+
+    public abstract Collection<String> getTags();
+
+    public abstract String getTransitionName();
+}

--- a/dialog/src/main/java/roboy/dialog/states/gameStates/GameState.java
+++ b/dialog/src/main/java/roboy/dialog/states/gameStates/GameState.java
@@ -7,6 +7,8 @@ import java.util.Collection;
 
 public abstract class GameState extends State {
 
+    public static String transitionName;
+
     /**
      * Create a state object with given identifier (state name) and parameters.
      * <p>
@@ -37,10 +39,4 @@ public abstract class GameState extends State {
      * @return Collection of tags
      */
     public abstract Collection<String> getTags();
-
-    /**
-     * Get the Transition name, that is used to denote the GameState
-     * @return Transition Name
-     */
-    public abstract String getTransitionName();
 }

--- a/dialog/src/main/java/roboy/dialog/states/gameStates/GameState.java
+++ b/dialog/src/main/java/roboy/dialog/states/gameStates/GameState.java
@@ -20,11 +20,27 @@ public abstract class GameState extends State {
         super(stateIdentifier, params);
     }
 
+    /**
+     * Can the game start?
+     * @return True if game is capable of starting
+     */
     public abstract boolean canStartGame();
 
+    /**
+     * What Roboy shall say to the user, explaining why he cannot start the given game, ie. Sorry, I need an internet connection to play World of Warcraft.
+     * @return Output that contains reasoning
+     */
     public abstract Output cannotStartWarning();
 
+    /**
+     * Tags that shall be used to infer, whether or not the user is specifically asking for a game. See {@link ChooseGameState}.infer method for how this is specifically implemented.
+     * @return Collection of tags
+     */
     public abstract Collection<String> getTags();
 
+    /**
+     * Get the Transition name, that is used to denote the GameState
+     * @return Transition Name
+     */
     public abstract String getTransitionName();
 }

--- a/dialog/src/main/java/roboy/dialog/states/gameStates/GameState.java
+++ b/dialog/src/main/java/roboy/dialog/states/gameStates/GameState.java
@@ -2,8 +2,10 @@ package roboy.dialog.states.gameStates;
 
 import roboy.dialog.states.definitions.State;
 import roboy.dialog.states.definitions.StateParameters;
+import roboy.linguistics.sentenceanalysis.Interpretation;
 
 import java.util.Collection;
+import java.util.List;
 
 public abstract class GameState extends State {
 
@@ -39,4 +41,18 @@ public abstract class GameState extends State {
      * @return Collection of tags
      */
     public abstract Collection<String> getTags();
+
+
+
+    public boolean checkUserSaidStop(Interpretation input){
+        boolean stopGame = false;
+        List<String> tokens = input.getTokens();
+        if(tokens != null && !tokens.isEmpty()){
+            if(tokens.contains("boring") || tokens.contains("stop") || tokens.contains("bored")){
+                stopGame = true;
+
+            }
+        }
+        return stopGame;
+    }
 }

--- a/dialog/src/main/java/roboy/dialog/states/gameStates/GamingSnapchatState.java
+++ b/dialog/src/main/java/roboy/dialog/states/gameStates/GamingSnapchatState.java
@@ -58,7 +58,8 @@ public class GamingSnapchatState extends GameState {
         Linguistics.UtteranceSentiment inputSentiment = getInference().inferSentiment(input);
         List<String> inputFilters = localInference.inferSnapchatFilter(input, EXISTING_FILTERS);
 
-        if(!checkUserSaidStop(input)) {
+        stopGame = checkUserSaidStop(input);
+        if(!stopGame) {
             if (inputSentiment == Linguistics.UtteranceSentiment.POSITIVE) {
                 desiredFilters.add(suggestedFilter);
             } else if (inputFilters != null) {
@@ -81,19 +82,6 @@ public class GamingSnapchatState extends GameState {
         } else {
             return this;
         }
-    }
-
-    private boolean checkUserSaidStop(Interpretation input){
-
-        stopGame = false;
-        List<String> tokens = input.getTokens();
-        if(tokens != null && !tokens.isEmpty()){
-                if(tokens.contains("boring") || tokens.contains("stop") || tokens.contains("bored")){
-                    stopGame = true;
-
-            }
-        }
-        return stopGame;
     }
 
     private Map<String, List<String>> buildSynonymMap(List<String> filters){
@@ -125,6 +113,7 @@ public class GamingSnapchatState extends GameState {
         return filterMap;
     }
 
+    @Override
     public boolean canStartGame(){
         return getRosMainNode() != null;
     }

--- a/dialog/src/main/java/roboy/dialog/states/gameStates/GamingSnapchatState.java
+++ b/dialog/src/main/java/roboy/dialog/states/gameStates/GamingSnapchatState.java
@@ -36,6 +36,8 @@ public class GamingSnapchatState extends GameState {
 
     private String suggestedFilter = "";
 
+    public static String transitionName = "choseSnapchat";
+
     public GamingSnapchatState(String stateIdentifier, StateParameters params) {
 
         super(stateIdentifier, params);
@@ -138,11 +140,6 @@ public class GamingSnapchatState extends GameState {
     @Override
     public Collection<String> getTags(){
         return Arrays.asList("snapchat", "filters", "filter");
-    }
-
-    @Override
-    public String getTransitionName() {
-        return "choseSnapchat";
     }
 
 }

--- a/dialog/src/main/java/roboy/dialog/states/gameStates/GamingSnapchatState.java
+++ b/dialog/src/main/java/roboy/dialog/states/gameStates/GamingSnapchatState.java
@@ -130,9 +130,8 @@ public class GamingSnapchatState extends GameState {
 
     @Override
     public Output cannotStartWarning() {
-        LOGGER.info("Trying to start Snapchat Game but ROS is not initialised.");
         Segue s = new Segue(Segue.SegueType.CONNECTING_PHRASE, 0.5);
-        return Output.say(Verbalizer.rosDisconnect.getRandomElement() + String.format("What a pity, %s. Snapchat is not possible right now. ",
+        return Output.say(Verbalizer.rosDisconnect.getRandomElement() + String.format("What a pity, %s. Snapchat is not possible right now.",
                 getContext().ACTIVE_INTERLOCUTOR.getValue().getName())).setSegue(s);
     }
 

--- a/dialog/src/main/java/roboy/dialog/states/gameStates/GamingSnapchatState.java
+++ b/dialog/src/main/java/roboy/dialog/states/gameStates/GamingSnapchatState.java
@@ -2,7 +2,6 @@ package roboy.dialog.states.gameStates;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.yecht.ruby.Out;
 import roboy.dialog.Segue;
 import roboy.dialog.states.definitions.State;
 import roboy.dialog.states.definitions.StateParameters;

--- a/dialog/src/main/java/roboy/dialog/states/gameStates/GamingSnapchatState.java
+++ b/dialog/src/main/java/roboy/dialog/states/gameStates/GamingSnapchatState.java
@@ -2,12 +2,15 @@ package roboy.dialog.states.gameStates;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.yecht.ruby.Out;
+import roboy.dialog.Segue;
 import roboy.dialog.states.definitions.State;
 import roboy.dialog.states.definitions.StateParameters;
 import roboy.linguistics.Linguistics;
 import roboy.linguistics.sentenceanalysis.Interpretation;
 import roboy.logic.Inference;
 import roboy.talk.PhraseCollection;
+import roboy.talk.Verbalizer;
 import roboy.util.RandomList;
 
 import java.util.*;
@@ -15,7 +18,7 @@ import java.util.*;
 import static roboy.util.FileLineReader.readFile;
 
 
-public class GamingSnapchatState extends State {
+public class GamingSnapchatState extends GameState {
 
     private final static String TRANSITION_GAME_ENDED = "gameEnded";
     private final static String EXISTING_FILTERS_ID = "filterFile";
@@ -119,6 +122,28 @@ public class GamingSnapchatState extends State {
             }
         }
         return filterMap;
+    }
+
+    public boolean canStartGame(){
+        return getRosMainNode() != null;
+    }
+
+    @Override
+    public Output cannotStartWarning() {
+        LOGGER.info("Trying to start Snapchat Game but ROS is not initialised.");
+        Segue s = new Segue(Segue.SegueType.CONNECTING_PHRASE, 0.5);
+        return Output.say(Verbalizer.rosDisconnect.getRandomElement() + String.format("What a pity, %s. Snapchat is not possible right now. ",
+                getContext().ACTIVE_INTERLOCUTOR.getValue().getName())).setSegue(s);
+    }
+
+    @Override
+    public Collection<String> getTags(){
+        return Arrays.asList("snapchat", "filters", "filter");
+    }
+
+    @Override
+    public String getTransitionName() {
+        return "choseSnapchat";
     }
 
 }

--- a/dialog/src/main/java/roboy/dialog/states/gameStates/GamingTwentyQuestionsState.java
+++ b/dialog/src/main/java/roboy/dialog/states/gameStates/GamingTwentyQuestionsState.java
@@ -50,35 +50,6 @@ public class GamingTwentyQuestionsState extends GameState {
 	}
 
 	@Override
-	public boolean canStartGame() {
-		setAW(false);
-		return aw!=null && aw.getServer().isUp();
-	}
-
-	@Override
-	public Output cannotStartWarning() {
-		return Output.say("Sorry, I need Internet Access to play this game");
-	}
-
-	@Override
-	public Collection<String> getTags(){
-		return Arrays.asList("akinator", "guessing", "questions");
-	}
-
-	private void setAW(boolean force){
-		if ((force || aw == null)) {
-			if(NetworkUtils.isInternetWorking()) {
-				aw = new AkiwrapperBuilder().setFilterProfanity(true).build();
-			}
-			else{
-				LOGGER.warn("No Internet Connection");
-			}
-		}
-		LOGGER.debug("AW Object already exists. Was not overwritten");
-	}
-
-
-	@Override
 	public Output act() {
 		setAW(false);
 		if(!userReady){
@@ -109,7 +80,8 @@ public class GamingTwentyQuestionsState extends GameState {
 		String intent = getIntent (input);
 		Linguistics.UtteranceSentiment inputSentiment = getInference().inferSentiment(input);
 
-		if(checkUserSaidStop(input)){
+		stopGame = checkUserSaidStop(input);
+		if(stopGame){
 			gameFinished = true;
 			return Output.sayNothing();
 
@@ -287,19 +259,6 @@ public class GamingTwentyQuestionsState extends GameState {
 		winner = "";
 	}
 
-	private boolean checkUserSaidStop(Interpretation input){
-
-		stopGame = false;
-		List<String> tokens = input.getTokens();
-		if(tokens != null && !tokens.isEmpty()){
-			if(tokens.contains("boring") || tokens.contains("stop") || tokens.contains("bored")){
-				stopGame = true;
-
-			}
-		}
-		return stopGame;
-	}
-
 	private void applyFilter(String winner){
 
 		if(winner.equals("roboy")){
@@ -311,5 +270,37 @@ public class GamingTwentyQuestionsState extends GameState {
 			emotionShown = getRosMainNode().ShowEmotion("tears");
 		}
 	}
+
+
+	@Override
+	public boolean canStartGame() {
+		setAW(false);
+		return aw!=null && aw.getServer().isUp();
+	}
+
+	@Override
+	public Output cannotStartWarning() {
+		return Output.say("Sorry, I need Internet Access to play this game");
+	}
+
+	@Override
+	public Collection<String> getTags(){
+		return Arrays.asList("akinator", "guessing", "questions");
+	}
+
+	private void setAW(boolean force){
+		if ((force || aw == null)) {
+			if(NetworkUtils.isInternetWorking()) {
+				aw = new AkiwrapperBuilder().setFilterProfanity(true).build();
+			}
+			else{
+				LOGGER.warn("No Internet Connection");
+			}
+		}
+		LOGGER.debug("AW Object already exists. Was not overwritten");
+	}
+
+
+
 
 }

--- a/dialog/src/main/java/roboy/dialog/states/gameStates/GamingTwentyQuestionsState.java
+++ b/dialog/src/main/java/roboy/dialog/states/gameStates/GamingTwentyQuestionsState.java
@@ -1,28 +1,22 @@
 package roboy.dialog.states.gameStates;
 
-import com.ibm.watson.developer_cloud.alchemy.v1.model.SAORelation;
 import com.markozajc.akiwrapper.Akiwrapper;
-import com.markozajc.akiwrapper.AkiwrapperBuilder;
-import com.markozajc.akiwrapper.core.entities.Question;
 import com.markozajc.akiwrapper.Akiwrapper.Answer;
+import com.markozajc.akiwrapper.AkiwrapperBuilder;
 import com.markozajc.akiwrapper.core.entities.Guess;
+import com.markozajc.akiwrapper.core.entities.Question;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import roboy.context.Context;
 import roboy.dialog.Segue;
 import roboy.dialog.states.definitions.State;
 import roboy.dialog.states.definitions.StateParameters;
 import roboy.linguistics.Linguistics;
 import roboy.linguistics.sentenceanalysis.Interpretation;
-import roboy.memory.nodes.Interlocutor;
-import roboy.ros.RosMainNode;
 import roboy.talk.PhraseCollection;
 import roboy.talk.Verbalizer;
 import roboy.util.NetworkUtils;
-import roboy.util.RandomList;
 
 import java.io.IOException;
-import java.lang.ref.PhantomReference;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;

--- a/dialog/src/main/java/roboy/dialog/states/gameStates/GamingTwentyQuestionsState.java
+++ b/dialog/src/main/java/roboy/dialog/states/gameStates/GamingTwentyQuestionsState.java
@@ -30,7 +30,6 @@ import java.util.List;
 
 public class GamingTwentyQuestionsState extends GameState {
 
-
 	private static final double PROBABILITY_THRESHOLD = 0.6;
 	private final static String TRANSITION_GAME_ENDED = "gameEnded";
 
@@ -50,6 +49,8 @@ public class GamingTwentyQuestionsState extends GameState {
 	private boolean emotionShown = false;
 	private String winner = "";
 
+	public static String transitionName = "chose20questions";
+
 	public GamingTwentyQuestionsState(String stateIdentifier, StateParameters params) {
 		super(stateIdentifier, params);
 	}
@@ -68,11 +69,6 @@ public class GamingTwentyQuestionsState extends GameState {
 	@Override
 	public Collection<String> getTags(){
 		return Arrays.asList("akinator", "guessing", "questions");
-	}
-
-	@Override
-	public String getTransitionName() {
-		return "chose20questions";
 	}
 
 	private void setAW(boolean force){

--- a/dialog/src/main/java/roboy/util/Maps.java
+++ b/dialog/src/main/java/roboy/util/Maps.java
@@ -1,7 +1,9 @@
 package roboy.util;
 
-import java.util.HashMap;
-import java.util.Map;
+import com.github.jsonldjava.utils.Obj;
+
+import java.util.*;
+import java.util.concurrent.ArrayBlockingQueue;
 
 /**
  * Helper class for map related tasks.
@@ -30,5 +32,23 @@ public class Maps {
 			result.put((Integer)elements[i],(String)elements[i+1]);
 		}
 		return result;
+	}
+
+	//The day when Java finally supports Bidirectional Maps...
+	public static <keys, values> Collection<keys> value2Keys(HashMap<keys, values> map, values value){
+		ArrayList<keys> collection = new ArrayList<>();
+		for(keys k : map.keySet()){
+			if(map.get(k).equals(value)){
+				collection.add(k);
+			}
+		}
+		return collection;
+	}
+	public static <keys, values> Optional<keys> value2Key(HashMap<keys, values> map, values value){
+		Collection<keys> v2k = value2Keys(map, value);
+		if(v2k==null || v2k.isEmpty() || v2k.size()>=2){
+			return Optional.empty();
+		}
+		else return v2k.stream().findFirst();
 	}
 }

--- a/dialog/src/main/java/roboy/util/NetworkUtils.java
+++ b/dialog/src/main/java/roboy/util/NetworkUtils.java
@@ -8,7 +8,7 @@ import java.net.InetSocketAddress;
 import java.net.Socket;
 
 public class NetworkUtils {
-    private static final int TIMEOUT = 250;
+    private static final int TIMEOUT = 1000;
     private static final Logger LOGGER = LogManager.getLogger();
 
     public static boolean isInternetWorking(String addr){
@@ -31,7 +31,7 @@ public class NetworkUtils {
     }
     //Shamelessly stolen from stackoverflow
     //Credits: https://stackoverflow.com/questions/9922543/why-does-inetaddress-isreachable-return-false-when-i-can-ping-the-ip-address
-    private static boolean isReachable(String addr, int timeOutMillis) {
+    public static boolean isReachable(String addr, int timeOutMillis) {
         try {
             try (Socket soc = new Socket()) {
                 soc.connect(new InetSocketAddress(addr, 80), timeOutMillis);

--- a/dialog/src/main/java/roboy/util/NetworkUtils.java
+++ b/dialog/src/main/java/roboy/util/NetworkUtils.java
@@ -1,0 +1,44 @@
+package roboy.util;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+
+public class NetworkUtils {
+    private static final int TIMEOUT = 250;
+    private static final Logger LOGGER = LogManager.getLogger();
+
+    public static boolean isInternetWorking(String addr){
+        return isReachable(addr, TIMEOUT);
+    }
+
+    /**
+     * Pings Cloudfare, Google and OpenDNS servers
+     */
+    public static boolean isInternetWorking(){
+        boolean cloudFlare = isInternetWorking("1.1.1.1"), google = isInternetWorking("172.217.22.46"), openDNS = isInternetWorking("146.112.62.105");
+        if(cloudFlare && google && openDNS){
+            LOGGER.debug("Internet working");
+            return true;
+        }
+        else{
+            LOGGER.warn(String.format("Cloudflare %s, Google %s, OpenDNS %s", cloudFlare, google, openDNS));
+            return false;
+        }
+    }
+    //Shamelessly stolen from stackoverflow
+    //Credits: https://stackoverflow.com/questions/9922543/why-does-inetaddress-isreachable-return-false-when-i-can-ping-the-ip-address
+    private static boolean isReachable(String addr, int timeOutMillis) {
+        try {
+            try (Socket soc = new Socket()) {
+                soc.connect(new InetSocketAddress(addr, 80), timeOutMillis);
+            }
+            return true;
+        } catch (IOException ex) {
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
Merge this after everyone else has finished their end term merges, it's not that pressing.

# Why

Games have entry conditions, you can only play them if ROS is enabled (Snapchat) or if the Internet is enabled (Akinator). Future games are likely to also have similar limitations. `ChooseGameState` must be able to handle this.

# What was done

Games now shall extend an abstract class GameState. This is so that we can record the entry conditions, error messages and tags in each class, rather then alter `ChooseGameState` massively. Hopefully fulfills OO principles a bit better.

Furthermore, only games that can be played shall be suggested and the game shall be checked once again before entering the state.

## Stuff Offloaded to GameStates

- Tags
- Start conditions
- Message if cannot start
- Transition Name
- Stop checking (code was copy pasted 2x)

## Extras

Additionally, some other features were implemented as a byproduct of this PR

- NetworkUtils that pings 3 different servers to check if the internet is working
- Map now has two new methods, to "recreate" a bidirectional map
- Akinator has been fixed to not crash program in no internet connection on startup
- Improved Logging

# Todo

- [ ] Document changes
- [ ] Test to isolate all bugs
- [ ] Improve HashMap creation process, some of it is pretty hacky
- [ ] Write Unit Tests